### PR TITLE
Adapt plugin to send events to Alfred

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,11 +6,11 @@
     <artifactId>stash2slack</artifactId>
     <version>1.3</version>
     <organization>
-        <name>Pragmatic Bits</name>
-        <url>http://blog.pragbits.com/</url>
+        <name>Equisoft</name>
+        <url>http://equisoft.com/</url>
     </organization>
-    <name>Slack notifications for pull request and push activities</name>
-    <description>Sends pull request activity and git push notifications to slack</description>
+    <name>Alfred notifications for pull request and push activities</name>
+    <description>Sends pull request activity and git push notifications to Alfred</description>
     <packaging>atlassian-plugin</packaging>
     <dependencyManagement>
         <dependencies>
@@ -125,6 +125,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
                 <configuration>
                     <source>1.6</source>
                     <target>1.6</target>

--- a/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
+++ b/src/main/java/com/pragbits/stash/components/PullRequestActivityListener.java
@@ -5,20 +5,21 @@ import com.atlassian.stash.event.pull.PullRequestActivityEvent;
 import com.atlassian.stash.event.pull.PullRequestCommentActivityEvent;
 import com.atlassian.stash.event.pull.PullRequestRescopeActivityEvent;
 import com.atlassian.stash.nav.NavBuilder;
-import com.atlassian.stash.pull.PullRequestActivity;
-import com.atlassian.stash.pull.PullRequestRescopeActivity;
-import com.atlassian.stash.pull.PullRequestState;
+import com.atlassian.stash.pull.*;
 import com.atlassian.stash.repository.Repository;
+import com.atlassian.stash.user.StashUser;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.pragbits.stash.SlackGlobalSettingsService;
 import com.pragbits.stash.SlackSettings;
 import com.pragbits.stash.SlackSettingsService;
+import com.pragbits.stash.models.PullRequestEvent;
 import com.pragbits.stash.tools.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.*;
 
 public class PullRequestActivityListener {
     static final String KEY_GLOBAL_SETTING_HOOK_URL = "stash2slack.globalsettings.hookurl";
@@ -52,94 +53,16 @@ public class PullRequestActivityListener {
             String localHookUrl = slackSettings.getSlackWebHookUrl();
             WebHookSelector hookSelector = new WebHookSelector(globalHookUrl, localHookUrl);
 
-            if (!hookSelector.isHookValid()) {
+            /*if (!hookSelector.isHookValid()) {
                 log.error("There is no valid configured Web hook url! Reason: " + hookSelector.getProblem());
                 return;
-            }
+            }*/
 
-            String repoName = repository.getSlug();
-            String projectName = repository.getProject().getKey();
-            long pullRequestId = event.getPullRequest().getId();
-            String userName = event.getUser() != null ? event.getUser().getDisplayName() : "unknown user";
-            String activity = event.getActivity().getAction().name();
+            PullRequestEvent eventToSend = new PullRequestEvent(event, navBuilder);
 
-            // Ignore RESCOPED PR events
-            if (activity.equalsIgnoreCase("RESCOPED") && event instanceof PullRequestRescopeActivityEvent) {
-                return;
-            }
+            String jsonPayload = gson.toJson(eventToSend);
 
-            String url = navBuilder
-                    .project(projectName)
-                    .repo(repoName)
-                    .pullRequest(pullRequestId)
-                    .overview()
-                    .buildAbsolute();
-
-            String text = String.format("Pull request event: `%s`, activity: `%s` by `%s`. <%s|See details>",
-                    event.getPullRequest().getTitle(),
-                    activity,
-                    userName,
-                    url);
-
-            SlackPayload payload = new SlackPayload();
-            if (!slackSettings.getSlackChannelName().isEmpty()) {
-                payload.setChannel(slackSettings.getSlackChannelName());
-            }
-            payload.setText(text);
-            payload.setMrkdwn(true);
-
-            SlackAttachment attachment = new SlackAttachment();
-            attachment.setFallback(text);
-            //attachment.setPretext(String.format(""));
-            attachment.setColor("#aabbcc");
-
-            SlackAttachmentField field = new SlackAttachmentField();
-            field.setTitle("Event details");
-
-            switch (event.getActivity().getAction()) {
-                case OPENED:
-                    field.setValue(String.format("*%s* OPENED the pull request: `%s`", userName,  event.getPullRequest().getTitle()));
-                    attachment.setColor("#2267c4"); // blue
-                    break;
-                case DECLINED:
-                    field.setValue(String.format("*%s* DECLINED the pull request", userName));
-                    attachment.setColor("#ff0024"); // red
-                    break;
-                case APPROVED:
-                    field.setValue(String.format("*%s* APPROVED the pull request", userName));
-                    attachment.setColor("#2dc422"); // green
-                    break;
-                case MERGED:
-                    field.setValue(String.format("*%s* MERGED the pull request", userName));
-                    attachment.setColor("#2dc422"); // green
-                    break;
-                case REOPENED:
-                    field.setValue(String.format("*%s* REOPENED the pull request", userName));
-                    attachment.setColor("#2267c4"); // blue
-                    break;
-                case RESCOPED:
-                    field.setValue(String.format("*%s* RESCOPED the pull request", userName));
-                    attachment.setColor("#9055fc"); // purple
-                    break;
-                case UNAPPROVED:
-                    field.setValue(String.format("*%s* UNAPPROVED the pull request", userName));
-                    attachment.setColor("#ff0024"); // red
-                    break;
-            }
-
-            if (event instanceof PullRequestCommentActivityEvent) {
-                field.setValue(String.format("*%s* commented the pull request: `%s`",
-                        userName,
-                        ((PullRequestCommentActivityEvent)event).getActivity().getComment().getText()));
-            }
-
-            field.setShort(false);
-            attachment.addField(field);
-            payload.addAttachment(attachment);
-            String jsonPayload = gson.toJson(payload);
-
-            slackNotifier.SendSlackNotification(hookSelector.getSelectedHook(), jsonPayload);
+            slackNotifier.SendSlackNotification(globalHookUrl, jsonPayload);
         }
-
     }
 }

--- a/src/main/java/com/pragbits/stash/models/PullRequest.java
+++ b/src/main/java/com/pragbits/stash/models/PullRequest.java
@@ -1,0 +1,47 @@
+package com.pragbits.stash.models;
+
+import com.atlassian.stash.nav.NavBuilder;
+import com.atlassian.stash.repository.Repository;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class PullRequest {
+    public PullRequestParticipant author;
+    public String title;
+    public String description;
+    public Collection<PullRequestParticipant> reviewers;
+    public Collection<PullRequestParticipant> participants;
+
+    public String url;
+
+    public PullRequest(com.atlassian.stash.pull.PullRequest pullRequest, NavBuilder navBuilder){
+        author = new PullRequestParticipant(pullRequest.getAuthor(), navBuilder);
+        description = pullRequest.getDescription();
+        title = pullRequest.getTitle();
+        reviewers = new ArrayList<PullRequestParticipant>();
+        for (com.atlassian.stash.pull.PullRequestParticipant reviewer : pullRequest.getReviewers()) {
+            reviewers.add(new PullRequestParticipant(reviewer, navBuilder));
+        }
+        participants = new ArrayList<PullRequestParticipant>();
+        for (com.atlassian.stash.pull.PullRequestParticipant participant : pullRequest.getParticipants()) {
+            participants.add(new PullRequestParticipant(participant, navBuilder));
+        }
+
+        setUrl(pullRequest, navBuilder);
+    }
+
+    private void setUrl(com.atlassian.stash.pull.PullRequest pullRequest, NavBuilder navBuilder){
+        Repository repository = pullRequest.getToRef().getRepository();
+        String repoName = repository.getSlug();
+        String projectName = repository.getProject().getKey();
+        long pullRequestId = pullRequest.getId();
+
+        url = navBuilder
+                .project(projectName)
+                .repo(repoName)
+                .pullRequest(pullRequestId)
+                .overview()
+                .buildAbsolute();
+    }
+}

--- a/src/main/java/com/pragbits/stash/models/PullRequestEvent.java
+++ b/src/main/java/com/pragbits/stash/models/PullRequestEvent.java
@@ -1,0 +1,16 @@
+package com.pragbits.stash.models;
+
+import com.atlassian.stash.nav.NavBuilder;
+
+public class PullRequestEvent {
+    public String action;
+    public StashUser user;
+    public PullRequest pullRequest;
+
+    public PullRequestEvent(com.atlassian.stash.event.pull.PullRequestActivityEvent event, NavBuilder navBuilder)
+    {
+        action = event.getAction().name();
+        user = new StashUser(event.getUser(), navBuilder);
+        pullRequest = new PullRequest(event.getPullRequest(), navBuilder);
+    }
+}

--- a/src/main/java/com/pragbits/stash/models/PullRequestParticipant.java
+++ b/src/main/java/com/pragbits/stash/models/PullRequestParticipant.java
@@ -1,0 +1,13 @@
+package com.pragbits.stash.models;
+
+import com.atlassian.stash.nav.NavBuilder;
+
+public class PullRequestParticipant {
+    public StashUser user;
+    public boolean approved;
+
+    public PullRequestParticipant(com.atlassian.stash.pull.PullRequestParticipant participant, NavBuilder navBuilder){
+        user = new StashUser(participant.getUser(), navBuilder);
+        approved = participant.isApproved();
+    }
+}

--- a/src/main/java/com/pragbits/stash/models/StashUser.java
+++ b/src/main/java/com/pragbits/stash/models/StashUser.java
@@ -1,0 +1,29 @@
+package com.pragbits.stash.models;
+
+import com.atlassian.stash.nav.NavBuilder;
+
+public class StashUser {
+    public int id;
+    public String email;
+    public String name;
+    public String displayName;
+    public String slug;
+
+    public String url;
+
+    public StashUser(com.atlassian.stash.user.StashUser user, NavBuilder navBuilder){
+        id = user.getId();
+        email = user.getEmailAddress();
+        name = user.getName();
+        displayName = user.getDisplayName();
+        slug = user.getSlug();
+
+        setUrl(user, navBuilder);
+    }
+
+    private void setUrl(com.atlassian.stash.user.StashUser user, NavBuilder navBuilder){
+        url = navBuilder
+                .userBySlug(user.getSlug())
+                .buildAbsolute();
+    }
+}


### PR DESCRIPTION
I modified the class responsible to send pull request notification to slack. Instead of sending to slack messages directly, we send a new pull request event, almost identical to the original, to Alfred. I build a new PullRequestEvent model since we can't directly parse the original event in JSON because of circular references.